### PR TITLE
Fix an error that appears during training

### DIFF
--- a/ovis/model/modeling_ovis.py
+++ b/ovis/model/modeling_ovis.py
@@ -201,9 +201,9 @@ class Ovis(OvisPreTrainedModel):
                 visual_embeds = [None] * len(num_images)
                 visual_input_ids = [None] * len(num_images)
                 visual_labels = [None] * len(num_images)
-            # just placeholders
-            if text_labels is None:
-                text_labels = torch.full(text_input_ids.shape, IGNORE_ID, dtype=torch.long, device=input_device)
+        # just placeholders
+        if text_labels is None:
+            text_labels = torch.full(text_input_ids.shape, IGNORE_ID, dtype=torch.long, device=input_device)
 
         input_embeds = []
         attention_masks = []


### PR DESCRIPTION
I'm trying to train the model, but I get the following error:
```
File ~/.cache/huggingface/modules/transformers_modules/AIDC-AI/Ovis2-1B/2ecddb375e78f79d65f54d513c62117849e29e0f/modeling_ovis.py:417, in Ovis.merge_multimodal(self, text_input_ids, text_attention_masks, text_labels, pixel_values, left_padding)
    415 attention_masks = []
    416 labels = []
--> 417 for text_input_id, text_label, text_attention_mask, visual_embed, visual_input_id, visual_label in zip(
    418         text_input_ids, text_labels, text_attention_masks, visual_embeds, visual_input_ids, visual_labels
    419 ):
    420     placeholder_token_mask = torch.lt(text_input_id, 0)
    421     text_embed = self.get_wte()(torch.masked_fill(text_input_id, placeholder_token_mask, 0))

TypeError: 'NoneType' object is not iterable
```
since the `merge_multimodal` function is explicitly called with `text_labels=None` in `generate` [here](https://github.com/AIDC-AI/Ovis/blob/fbe20e79239ff2786ce5d192bc194630034e9ec9/ovis/model/modeling_ovis.py#L425)